### PR TITLE
Skip portlethash check when it's None for minimal support for collective.panels

### DIFF
--- a/src/collective/portlet/fullview/fullview.py
+++ b/src/collective/portlet/fullview/fullview.py
@@ -127,6 +127,9 @@ class Renderer(base.Renderer):
         located.
         """
         portlethash = self.portlethash
+        if portlethash is None:
+            return True
+
         if self.request.get('portlet_rendered_{0}'.format(portlethash), False):
             return False
         self.request.set('portlet_rendered_{0}'.format(portlethash), True)


### PR DESCRIPTION
Getting portlethash didn't work out with collective.panels.

@thet How should I be able to reproduce the recursion error? Probably that's not so big issue with collective.panels, where portlets won't inherit by defult (yet, probably that issue is still reproducible there).
