### PR TITLE
Fix to use implicit 'folder_full_view' when item macro cannot be found

### DIFF
--- a/src/collective/portlet/fullview/fullview_item.pt
+++ b/src/collective/portlet/fullview/fullview_item.pt
@@ -44,6 +44,18 @@
       <div tal:replace="structure provider:plone.belowcontentbody" />
     </tal:block>
 
+    <tal:block tal:condition="not:item_macro">
+        <metal:block use-macro="context/folder_listing/macros/listing">
+            <metal:entries fill-slot="entries">
+                <metal:block use-macro="context/folder_listing/macros/entries">
+                    <metal:entry fill-slot="entry">
+                        <div tal:replace="structure python:item.getObject().folder_full_view_item()" />
+                    </metal:entry>
+                </metal:block>
+            </metal:entries>
+        </metal:block>
+    </tal:block>
+
     </tal:show_content>
 
     <div class="visualClear"><!-- --></div>


### PR DESCRIPTION
This was my main issue with c.p.fullview. I didn't get almost any behavior out of the box, because most of the Plone default folder views don't provide context-core -macro.
